### PR TITLE
fix: replace local shadcn cli reference with 'shadcn build'

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "registry:build": "node ~/code/shadcn/ui/packages/shadcn/dist/index.js build"
+    "registry:build": "shadcn build"
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.4",


### PR DESCRIPTION
The current state in the main branch can not run registry:build as the shadcn CLI is currently linked to a local installation under `~/code…`.
FYI @shadcn 