### PR TITLE
fix: build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "registry:build": "node ~/code/shadcn/ui/packages/shadcn/dist/index.js build"
+    "registry:build": "shadcn build"
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.4",


### PR DESCRIPTION
Build command has to use `shadcn build`,  currently is:
```node ~/code/shadcn/ui/packages/shadcn/dist/index.js build```
 guess that was a refuse.