### PR TITLE
feat: add environment configuration and update documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# change this to your production url when deploying
+NEXT_PUBLIC_BASE_URL="http://localhost:3000"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ This is a template for creating a custom registry using Next.js.
 - Every registry item are compatible with the `shadcn` CLI.
 - We have also added v0 integration using the `Open in v0` api.
 
+## Environment Configuration
+
+For the "Open in v0" feature to work properly, you need to set the correct deployment URL:
+
+1. Copy `.env.example` to `.env`
+2. Update `NEXT_PUBLIC_BASE_URL` to your deployed registry URL (e.g., `https://registry-template.vercel.app`)
+
+```bash
+cp .env.example .env
+# Edit .env and set NEXT_PUBLIC_BASE_URL to your deployment URL
+```
+
 ## Documentation
 
 Visit the [shadcn documentation](https://ui.shadcn.com/docs/registry) to view the full documentation.


### PR DESCRIPTION
## Summary

- Add `.env.example` file with environment configuration template
- Update `.gitignore` to include `.env.example` in version control
- Update README with environment configuration instructions for v0 integration

## Changes

- **Added**: `.env.example` with `NEXT_PUBLIC_BASE_URL` configuration
- **Modified**: `.gitignore` to exclude `.env*` files but include `.env.example`
- **Modified**: `README.md` with new "Environment Configuration" section explaining how to set up the deployment URL for the "Open in v0" feature